### PR TITLE
feat(settings): pull-to-refresh re-fetches the model list

### DIFF
--- a/lib/screens/nexus/settings_tab.dart
+++ b/lib/screens/nexus/settings_tab.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/app_mode_provider.dart';
 import '../../providers/billing_providers.dart';
+import '../../providers/models_provider.dart';
 import '../../providers/nexus_gateway_provider.dart';
 import '../../providers/omni_router_provider.dart';
 import '../../providers/theme_provider.dart';
@@ -36,17 +37,25 @@ class SettingsTab extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final mode = ref.watch(appModeProvider);
 
-    return ListView(
-      padding: const EdgeInsets.all(16),
-      children: [
-        _profile(context, ref),
-        const SizedBox(height: 18),
-        if (mode.showsModelManager) ...[
-          const ModelManager(),
+    // Pull-to-refresh re-fetches the installed model list from the selected
+    // server, so models installed/removed outside the app (e.g. via the
+    // Lemonade server itself or another client) show up without a restart —
+    // the list otherwise only updates on server/app-mode changes.
+    return RefreshIndicator(
+      onRefresh: () => ref.read(modelsProvider.notifier).fetchModels(),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(16),
+        children: [
+          _profile(context, ref),
           const SizedBox(height: 18),
+          if (mode.showsModelManager) ...[
+            const ModelManager(),
+            const SizedBox(height: 18),
+          ],
+          ..._groups(context, ref),
         ],
-        ..._groups(context, ref),
-      ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Problem

The installed-model list (Model Manager on the Settings tab, Local AI / Mesh modes)
only re-fetches from the server when the selected server or app mode changes —
`ModelsNotifier` sets up `ref.listen` on those two providers and nothing else
re-triggers `fetchModels()` on that screen. If you install or remove a model
outside the app (via the Lemonade server itself, `lemonade-server pull`, or another
client), the list goes stale and the only way to see the change is to switch
servers or kill and restart the app.

## Fix

Wrap the Settings tab's `ListView` in a `RefreshIndicator` whose `onRefresh`
awaits `ref.read(modelsProvider.notifier).fetchModels()` — the exact same fetch
the screen already uses — so the spinner dismisses when the re-fetch completes.
`AlwaysScrollableScrollPhysics` is set so the pull gesture works even when the
content fits on screen.

This mirrors the pattern the app already uses elsewhere
(`omni_router_screen.dart`, `account_screen.dart`, `admin_models_tab.dart`):
`RefreshIndicator` + the screen's existing fetch.

One file changed: `lib/screens/nexus/settings_tab.dart` (+1 import, wrap the
existing `ListView`).

## How verified

- `flutter analyze` (Flutter 3.44.4 stable, after `dart run build_runner build`
  for the gitignored Isar `*.g.dart` files): no issues in the changed file;
  the 20 reported issues (infos/warnings in `models_provider.dart`,
  `voice_mode_provider.dart`, etc.) are pre-existing on `main` — verified by
  stashing the change and re-running analyze (same 20).
- `flutter build apk --release --target-platform android-arm64` (and
  `--split-per-abi`) both build successfully; the arm64-v8a APK passes
  `apksigner verify`. Not yet exercised on a physical device — behavior below
  is by code path.
- Expected behavior: pulling down on the Settings tab shows the Material
  refresh spinner, `fetchModels()` re-hits the models endpoint on the selected
  server, and the Models/Collections sections rebuild from the updated provider
  state (`ModelManager` watches `modelsProvider`, so no other wiring was
  needed). `fetchModels()` catches its own errors (stale list becomes empty on
  failure, same as existing behavior everywhere else it's called), so the
  indicator always completes.

Scope kept to the models screen only, per the gap being reported — other tabs
were left untouched.

- Device-tested on a physical arm64 phone (Pixel-class, sideloaded release APK): pull down on the Settings tab after `lemonade-server pull` of a new model → list refreshes and the new model appears.

---
AI-assisted change, human-reviewed and verified on real hardware (Ryzen AI MAX 395 dev box + physical Android device) per the project's AI contribution policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)