### PR TITLE
fix(ui): truncate long model names in compact ModelSelector pill

### DIFF
--- a/lib/widgets/model_selector.dart
+++ b/lib/widgets/model_selector.dart
@@ -82,13 +82,19 @@ class ModelSelector extends ConsumerWidget {
               borderRadius: BorderRadius.circular(16),
             ),
             child: Row(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  selectedModel ?? 'Select Model',
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
-                    color: Theme.of(context).colorScheme.onSurface,
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 160),
+                  child: Text(
+                    selectedModel ?? 'Select Model',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
                   ),
                 ),
                 const SizedBox(width: 4),


### PR DESCRIPTION
## Problem

In the chat screen AppBar, the compact `ModelSelector` pill renders the selected model id in an unconstrained `Text`. Long model names (e.g. `Lemonade-LFM2.5-1.2B-Instruct-FP8`) make the pill grow until it clips into the hamburger/menu action, which becomes tappable over nothing / visually hidden.

Observed on an S25 Ultra running v3.1.4+20 with a long local model name selected.

## Fix

- Wrap the pill label in a `ConstrainedBox` (maxWidth: 160) with `maxLines: 1` and `TextOverflow.ellipsis`.
- Set `mainAxisSize: MainAxisSize.min` on the pill Row so it never inflates past its content.

The widget keeps its full visual style; long names simply ellipsize. The full model id remains visible in the popup menu items, which already use `Expanded`.

## Note

The Nexus redesign (3.4.0) no longer mounts this widget in the live header, but `lib/widgets/model_selector.dart` is still shipped on `main` and is identical to the 3.1.4 version, so this fix applies to both the released 3.1.4 line and current `main`. Happy to drop it if you intend to delete the widget instead.